### PR TITLE
revealjs: smarter separators

### DIFF
--- a/revealjs/index.html
+++ b/revealjs/index.html
@@ -31,10 +31,10 @@
 		<div class="reveal">
 			<div class="slides">
 			<section data-markdown="md/slides.md"
-			         data-separator="^---\n"
-			         data-vertical="^-"
-			         data-notes="^Note:"
-			         data-charset="utf-8">
+				 data-separator="^-{3,}\s*\n"
+				 data-vertical="^-{1,2}\s*\n"
+				 data-notes="^Note:"
+				 data-charset="utf-8">
 			</section>
 			</div>
 		</div>


### PR DESCRIPTION
"-" is a poor choice of data separator because it means that you cannot use a dash in lists any more. The below change allows continued use of "-" alone in a line as a data separator but also allows two dashes, which I prefer.
- three or more dashes plus whitespace only in a line: new column
- one or two dashes plus whitespace only in a line: new slide

Example markdown:

```
## Column 1

-

### Slide 1-1

--

### Slide 1-2

--------

## Column 2

--

### Slide 2-1

----        

## Column 3

-     

### Slide 3-1

-

### Slide 3-2
```
